### PR TITLE
fix: create change collector after model is build, but before it's refactoring starts

### DIFF
--- a/src/main/java/TestHelp.java
+++ b/src/main/java/TestHelp.java
@@ -1,15 +1,11 @@
 import org.json.JSONArray;
-import org.sonar.java.checks.AbsOnNegativeCheck;
 import spoon.Launcher;
 import spoon.experimental.modelobs.SourceFragmentsTreeCreatingChangeCollector;
 import spoon.processing.Processor;
 
-import spoon.reflect.factory.Factory;
 import spoon.reflect.visitor.PrettyPrinter;
 import spoon.reflect.visitor.printer.change.ChangesAwareDefaultJavaPrettyPrinter;
 
-import spoon.experimental.modelobs.SourceFragmentsTreeCreatingChangeCollector;
-import spoon.reflect.factory.Factory;
 
 
 
@@ -51,8 +47,12 @@ public class TestHelp {
         Launcher launcher = new Launcher() {
         	@Override
         	public PrettyPrinter createPrettyPrinter() {
-                new SourceFragmentsTreeCreatingChangeCollector().attachTo(factory.getEnvironment());
         		return new ChangesAwareDefaultJavaPrettyPrinter(getEnvironment());
+        	}
+        	@Override
+        	public void process() {
+                new SourceFragmentsTreeCreatingChangeCollector().attachTo(factory.getEnvironment());
+        		super.process();
         	}
         };
 


### PR DESCRIPTION
This needs latest change from Spoon PR https://github.com/INRIA/spoon/pull/1927 too

So now Sniper is really used, but it fails on inconsistent Source position of 
```java
((long) something.getLine())
```
where type cast `(long)` is problem ... https://github.com/INRIA/spoon/issues/2055
