### PR TITLE
Array to string processor

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,4 @@
 language: java
 
 jdk:
-  - oraclejdk8
+  - oraclejdk9

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,4 @@
 language: java
 
 jdk:
-  - oraclejdk10
+  - openjdk10

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,4 @@
 language: java
 
 jdk:
-  - oraclejdk9
+  - oraclejdk10

--- a/pom.xml
+++ b/pom.xml
@@ -30,13 +30,13 @@
         </dependency>
         -->
 
-        <!--
+
         <dependency>
             <groupId>fr.inria.gforge.spoon</groupId>
             <artifactId>spoon-core</artifactId>
-            <version>7.1.0-SNAPSHOT</version>
+            <version>7.5.0</version>
         </dependency>
-        -->
+
 
         <dependency>
             <groupId>org.sonar.java</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -37,7 +37,7 @@
             <version>7.5.0</version>
         </dependency>
 
-
+<!--
         <dependency>
             <groupId>org.sonar.java</groupId>
             <artifactId>Project</artifactId>
@@ -45,11 +45,18 @@
             <scope>system</scope>
             <systemPath>${basedir}/lib/java-checks-testkit-5.5.0-SNAPSHOT.jar</systemPath>
         </dependency>
+-->
+        <dependency>
+            <groupId>org.sonarsource.java</groupId>
+            <artifactId>java-checks-testkit</artifactId>
+            <version>5.5.0.14655</version>
+            <scope>test</scope>
+        </dependency>
 
         <dependency>
             <groupId>org.sonarsource.java</groupId>
             <artifactId>sonar-java-plugin</artifactId>
-            <version>5.4.0.14284</version>
+            <version>5.7.0.15470</version>
         </dependency>
 
         <dependency>

--- a/src/main/java/ArrayToStringProcessor.java
+++ b/src/main/java/ArrayToStringProcessor.java
@@ -41,7 +41,6 @@ public class ArrayToStringProcessor extends AbstractProcessor<CtInvocation<?>> {
             method = (CtMethod) arraysClass.getMethodsByName(TOSTRING).get(0);
         } else {
             System.err.println("Unhandled case. Something went wrong.");
-            System.exit(1);
         }
         CtExecutableReference refToMethod = getFactory().Executable().createReference(method);
         CtInvocation newInvocation  = getFactory().Code().createInvocation(newTarget, refToMethod, prevTarget);

--- a/src/main/java/ArrayToStringProcessor.java
+++ b/src/main/java/ArrayToStringProcessor.java
@@ -53,17 +53,12 @@ public class ArrayToStringProcessor extends AbstractProcessor<CtInvocation<?>> {
     }
     @Override
     public void process(CtInvocation<?> element) {
-        CtExpression target = element.getTarget();
-        // System.out.println(target);
-        // CtCodeSnippetExpression snippetExpression = getFactory().Code().createCodeSnippetExpression("Arrays.toString(" + target + ")");
-        CtCodeSnippetExpression snippetExpression = getFactory().Code().createCodeSnippetExpression("Arrays");
-
+        CtExpression prevTarget = element.getTarget();
+        CtCodeSnippetExpression newTarget = getFactory().Code().createCodeSnippetExpression("Arrays");
         CtType arraysClass = getFactory().Class().get(Arrays.class);
         CtMethod toStringMethod = (CtMethod) arraysClass.getMethodsByName("toString").get(0);
-        System.out.println(toStringMethod);
         CtExecutableReference refToString = getFactory().Executable().createReference(toStringMethod);
-        refToString.setStatic(true);
-        CtInvocation arraysToString = getFactory().Code().createInvocation(null, refToString, target);
+        CtInvocation arraysToString = getFactory().Code().createInvocation(newTarget, refToString, prevTarget);
 
         arraysToString.setImplicit(false);
 

--- a/src/main/java/ArrayToStringProcessor.java
+++ b/src/main/java/ArrayToStringProcessor.java
@@ -1,0 +1,76 @@
+import org.json.JSONArray;
+import org.json.JSONException;
+import spoon.processing.AbstractProcessor;
+import spoon.reflect.code.*;
+import spoon.reflect.cu.SourcePosition;
+import spoon.reflect.declaration.CtElement;
+import spoon.reflect.declaration.CtMethod;
+import spoon.reflect.declaration.CtType;
+import spoon.reflect.reference.CtExecutableReference;
+
+import java.util.Arrays;
+import java.util.HashSet;
+import java.util.Set;
+
+import static java.lang.Math.abs;
+
+
+public class ArrayToStringProcessor extends AbstractProcessor<CtInvocation<?>> {
+
+    private JSONArray jsonArray;//array of JSONObjects, each of which is a bug
+    private Set<Bug> SetOfBugs;//set of bugs, corresponding to jsonArray
+    private Set<Long> SetOfLineNumbers;//set of line numbers corresponding to bugs, just for efficiency
+    private Set<String> SetOfFileNames;//-----
+    private Bug thisBug;               //current bug. This is set inside isToBeProcessed function
+    private String thisBugName;        //name (message) of current thisBug.
+
+    public ArrayToStringProcessor(String projectKey) throws Exception {
+        jsonArray= ParseAPI.parse(2116,"",projectKey);
+        SetOfBugs = Bug.createSetOfBugs(this.jsonArray);
+        SetOfLineNumbers=new HashSet<Long>();
+        SetOfFileNames=new HashSet<String>();
+        thisBug=new Bug();
+        for(Bug bug:SetOfBugs)
+        {
+            SetOfLineNumbers.add(bug.getLineNumber());
+            SetOfFileNames.add(bug.getFileName());
+        }
+    }
+
+    @Override
+    public boolean isToBeProcessed(CtInvocation<?> candidate)
+    {
+        if(candidate==null||candidate.getTarget()==null)
+        {
+            return false;
+        }
+        if(candidate.getTarget().getType().isArray()){
+            if(candidate.getExecutable().toString().equals("toString()")){
+                return true;
+            }
+        }
+        return false;
+    }
+    @Override
+    public void process(CtInvocation<?> element) {
+        CtExpression target = element.getTarget();
+        // System.out.println(target);
+        // CtCodeSnippetExpression snippetExpression = getFactory().Code().createCodeSnippetExpression("Arrays.toString(" + target + ")");
+        CtCodeSnippetExpression snippetExpression = getFactory().Code().createCodeSnippetExpression("Arrays");
+
+        CtType arraysClass = getFactory().Class().get(Arrays.class);
+        CtMethod toStringMethod = (CtMethod) arraysClass.getMethodsByName("toString").get(0);
+        System.out.println(toStringMethod);
+        CtExecutableReference refToString = getFactory().Executable().createReference(toStringMethod);
+        refToString.setStatic(true);
+        CtInvocation arraysToString = getFactory().Code().createInvocation(null, refToString, target);
+
+        arraysToString.setImplicit(false);
+
+        // CtCodeSnippetStatement snippetExpression2 = getFactory().Code().createCodeSnippetStatement("Arrays2");
+        // CtElement target2 = element.getExecutable();
+        element.replace(arraysToString);
+        // target2.replace(snippetExpression2);
+        // element.delete();
+    }
+}

--- a/src/main/java/ArrayToStringProcessor.java
+++ b/src/main/java/ArrayToStringProcessor.java
@@ -1,40 +1,17 @@
-import org.json.JSONArray;
-import org.json.JSONException;
 import spoon.processing.AbstractProcessor;
 import spoon.reflect.code.*;
-import spoon.reflect.cu.SourcePosition;
-import spoon.reflect.declaration.CtElement;
 import spoon.reflect.declaration.CtMethod;
 import spoon.reflect.declaration.CtType;
 import spoon.reflect.reference.CtExecutableReference;
-
 import java.util.Arrays;
-import java.util.HashSet;
-import java.util.Set;
-
-import static java.lang.Math.abs;
-
 
 public class ArrayToStringProcessor extends AbstractProcessor<CtInvocation<?>> {
 
-    private JSONArray jsonArray;//array of JSONObjects, each of which is a bug
-    private Set<Bug> SetOfBugs;//set of bugs, corresponding to jsonArray
-    private Set<Long> SetOfLineNumbers;//set of line numbers corresponding to bugs, just for efficiency
-    private Set<String> SetOfFileNames;//-----
-    private Bug thisBug;               //current bug. This is set inside isToBeProcessed function
-    private String thisBugName;        //name (message) of current thisBug.
+    final String TOSTRING = "toString";
+    final String HASHCODE = "hashCode";
 
     public ArrayToStringProcessor(String projectKey) throws Exception {
-        jsonArray= ParseAPI.parse(2116,"",projectKey);
-        SetOfBugs = Bug.createSetOfBugs(this.jsonArray);
-        SetOfLineNumbers=new HashSet<Long>();
-        SetOfFileNames=new HashSet<String>();
-        thisBug=new Bug();
-        for(Bug bug:SetOfBugs)
-        {
-            SetOfLineNumbers.add(bug.getLineNumber());
-            SetOfFileNames.add(bug.getFileName());
-        }
+        ParseAPI.parse(2116,"",projectKey);
     }
 
     @Override
@@ -45,7 +22,8 @@ public class ArrayToStringProcessor extends AbstractProcessor<CtInvocation<?>> {
             return false;
         }
         if(candidate.getTarget().getType().isArray()){
-            if(candidate.getExecutable().toString().equals("toString()")){
+            if(candidate.getExecutable().toString().equals(TOSTRING + "()") ||
+                    (candidate.getExecutable().toString().equals(HASHCODE + "()"))){
                 return true;
             }
         }
@@ -56,16 +34,17 @@ public class ArrayToStringProcessor extends AbstractProcessor<CtInvocation<?>> {
         CtExpression prevTarget = element.getTarget();
         CtCodeSnippetExpression newTarget = getFactory().Code().createCodeSnippetExpression("Arrays");
         CtType arraysClass = getFactory().Class().get(Arrays.class);
-        CtMethod toStringMethod = (CtMethod) arraysClass.getMethodsByName("toString").get(0);
-        CtExecutableReference refToString = getFactory().Executable().createReference(toStringMethod);
-        CtInvocation arraysToString = getFactory().Code().createInvocation(newTarget, refToString, prevTarget);
-
-        arraysToString.setImplicit(false);
-
-        // CtCodeSnippetStatement snippetExpression2 = getFactory().Code().createCodeSnippetStatement("Arrays2");
-        // CtElement target2 = element.getExecutable();
-        element.replace(arraysToString);
-        // target2.replace(snippetExpression2);
-        // element.delete();
+        CtMethod method = null;
+        if(element.getExecutable().toString().equals(HASHCODE + "()")){
+            method = (CtMethod) arraysClass.getMethodsByName(HASHCODE).get(0);
+        } else if(element.getExecutable().toString().equals(TOSTRING + "()")){
+            method = (CtMethod) arraysClass.getMethodsByName(TOSTRING).get(0);
+        } else {
+            System.err.println("Unhandled case. Something went wrong.");
+            System.exit(1);
+        }
+        CtExecutableReference refToMethod = getFactory().Executable().createReference(method);
+        CtInvocation newInvocation  = getFactory().Code().createInvocation(newTarget, refToMethod, prevTarget);
+        element.replace(newInvocation);
     }
 }

--- a/src/main/java/Main.java
+++ b/src/main/java/Main.java
@@ -9,7 +9,7 @@ public class Main {
     {
 
         String projectKey="fr.inria.gforge.spoon:spoon-core";
-        int rulenumber = 1854;
+        int rulenumber = 2116;
         if(args.length>0)
         {
             rulenumber = Integer.parseInt(args[0]);
@@ -33,7 +33,7 @@ public class Main {
         {
             System.out.println("No arguments given. Using "+ TestHelp.getProcessor(rulenumber).getName()+ " by default on "+projectKey);
         }
-        TestHelp.repair("./source/act/",projectKey,rulenumber);
+        TestHelp.normalRepair("./source/act/",projectKey,rulenumber);
         System.out.println("done");
 	}
 }

--- a/src/main/java/NonSerializableSuperClassProcessor.java
+++ b/src/main/java/NonSerializableSuperClassProcessor.java
@@ -1,3 +1,4 @@
+/*
 import org.json.JSONArray;
 import org.json.JSONException;
 import spoon.processing.AbstractProcessor;
@@ -150,3 +151,4 @@ public class NonSerializableSuperClassProcessor extends AbstractProcessor<CtClas
         }
     }
 }
+*/

--- a/src/main/java/NonSerializableSuperClassProcessor.java
+++ b/src/main/java/NonSerializableSuperClassProcessor.java
@@ -1,3 +1,8 @@
+/**
+ * DISABLED as per commit b965cad6f327d8fd0fb97a3af8f6427de61685c4.
+ * The test is unable to find the error in the initial state. See commit message above for more info.
+ */
+/*
 /*
 import org.json.JSONArray;
 import org.json.JSONException;

--- a/src/main/java/NullDereferenceProcessor.java
+++ b/src/main/java/NullDereferenceProcessor.java
@@ -1,3 +1,8 @@
+/**
+ * DISABLED as per commit b965cad6f327d8fd0fb97a3af8f6427de61685c4
+ * The processor is non-functioning. See commit message above for more info.
+ */
+/*
 /*
 import org.json.JSONArray;
 import org.json.JSONException;

--- a/src/main/java/NullDereferenceProcessor.java
+++ b/src/main/java/NullDereferenceProcessor.java
@@ -1,3 +1,4 @@
+/*
 import org.json.JSONArray;
 import org.json.JSONException;
 import spoon.processing.AbstractProcessor;
@@ -139,3 +140,4 @@ public class NullDereferenceProcessor extends AbstractProcessor<CtInvocation<?>>
         }
     }
 }
+*/

--- a/src/main/java/ParseAPI.java
+++ b/src/main/java/ParseAPI.java
@@ -58,7 +58,7 @@ public class ParseAPI {
             System.out.println("Here is the JSON response from Sonarqube:");
             System.out.println(jo.toString());
         }
-        if(projectKey.equals("se.kth:sonatest"))
+        if(projectKey.equals("fr.inria.gforge.spoon:spoon-core"))
         {
             System.out.println(jsonArray.toString());
         }

--- a/src/main/java/TestHelp.java
+++ b/src/main/java/TestHelp.java
@@ -85,15 +85,16 @@ public class TestHelp {
     Simple helper method that removes the mandatory // Noncompliant comments from test files.
      */
     public static void removeComplianceComments(String pathToRepairedFile) {
+        final String complianceComment = "// Noncompliant";
         try {
             BufferedReader file = new BufferedReader(new FileReader(pathToRepairedFile));
             StringBuffer inputBuffer = new StringBuffer();
             String line;
 
             while ((line = file.readLine()) != null) {
-                if(line.contains("// Noncompliant")){
+                if(line.contains(complianceComment)){
                     line.trim();
-                    line = line.substring(0, line.length() - ("//Noncompliant".length()) - 1);
+                    line = line.substring(0, line.length() - (complianceComment.length()));
                 }
                 inputBuffer.append(line+'\n');
             }

--- a/src/main/java/TestHelp.java
+++ b/src/main/java/TestHelp.java
@@ -1,6 +1,9 @@
 import spoon.Launcher;
 // import spoon.support.modelobs.SourceFragmentsTreeCreatingChangeCollector;
 import spoon.processing.Processor;
+import java.io.BufferedReader;
+import java.io.FileReader;
+import java.io.FileOutputStream;
 import spoon.reflect.visitor.PrettyPrinter;
 // import spoon.reflect.visitor.printer.change.SniperJavaPrettyPrinter;
 
@@ -76,6 +79,32 @@ public class TestHelp {
         launcher.addProcessor((Processor) object);
         launcher.run();
 //        new SpoonModelTree(launcher.getFactory());
+    }
+
+    /*
+    Simple helper method that removes the mandatory // Noncompliant comments from test files.
+     */
+    public static void removeComplianceComments(String pathToRepairedFile) {
+        try {
+            BufferedReader file = new BufferedReader(new FileReader(pathToRepairedFile));
+            StringBuffer inputBuffer = new StringBuffer();
+            String line;
+
+            while ((line = file.readLine()) != null) {
+                if(line.contains("// Noncompliant")){
+                    line.trim();
+                    line = line.substring(0, line.length() - ("//Noncompliant".length()) - 1);
+                }
+                inputBuffer.append(line+'\n');
+            }
+            file.close();
+            FileOutputStream fileOut = new FileOutputStream(pathToRepairedFile);
+            fileOut.write(inputBuffer.toString().getBytes());
+            fileOut.close();
+
+        } catch (Exception e) {
+            System.out.println("Problem reading file.");
+        }
     }
 
     public static void copy(String from, String to) {

--- a/src/main/java/TestHelp.java
+++ b/src/main/java/TestHelp.java
@@ -4,7 +4,6 @@ import spoon.processing.Processor;
 import java.io.BufferedReader;
 import java.io.FileReader;
 import java.io.FileOutputStream;
-import spoon.reflect.visitor.PrettyPrinter;
 // import spoon.reflect.visitor.printer.change.SniperJavaPrettyPrinter;
 
 import java.lang.reflect.Constructor;
@@ -21,10 +20,10 @@ public class TestHelp {
         rule = new HashMap<>();
         rule.putIfAbsent(1854, DeadStoreProcessor.class);
         rule.putIfAbsent(1948, SerializableFieldProcessor.class);
-        rule.putIfAbsent(2055, NonSerializableSuperClassProcessor.class);
+        // rule.putIfAbsent(2055, NonSerializableSuperClassProcessor.class);
         rule.putIfAbsent(2095, ResourceCloseProcessor.class);
         rule.putIfAbsent(2116, ArrayToStringProcessor.class);
-        rule.putIfAbsent(2259, NullDereferenceProcessor.class);
+        // rule.putIfAbsent(2259, NullDereferenceProcessor.class);
     }
 
     public static Class<?> getProcessor(int ruleKey) {

--- a/src/main/java/TestHelp.java
+++ b/src/main/java/TestHelp.java
@@ -1,8 +1,8 @@
 import spoon.Launcher;
-import spoon.experimental.modelobs.SourceFragmentsTreeCreatingChangeCollector;
+// import spoon.support.modelobs.SourceFragmentsTreeCreatingChangeCollector;
 import spoon.processing.Processor;
 import spoon.reflect.visitor.PrettyPrinter;
-import spoon.reflect.visitor.printer.change.SniperJavaPrettyPrinter;
+// import spoon.reflect.visitor.printer.change.SniperJavaPrettyPrinter;
 
 import java.lang.reflect.Constructor;
 import java.util.HashMap;
@@ -20,6 +20,7 @@ public class TestHelp {
         rule.putIfAbsent(1948, SerializableFieldProcessor.class);
         rule.putIfAbsent(2055, NonSerializableSuperClassProcessor.class);
         rule.putIfAbsent(2095, ResourceCloseProcessor.class);
+        rule.putIfAbsent(2116, ArrayToStringProcessor.class);
         rule.putIfAbsent(2259, NullDereferenceProcessor.class);
     }
 
@@ -34,6 +35,7 @@ public class TestHelp {
         return rule.get(ruleKey);
     }
 
+    /*
     public static void repair(String pathToFile, String projectKey, int rulekey) throws Exception
     {
         Launcher launcher = new Launcher() {
@@ -60,6 +62,7 @@ public class TestHelp {
         launcher.run();
 //        new SpoonModelTree(launcher.getFactory());
     }
+    */
 
     public static void normalRepair(String pathToFile, String projectKey, int rulekey) throws Exception {
         //Not Sniper  Mode

--- a/src/test/java/ArrayToStringProcessorTest.java
+++ b/src/test/java/ArrayToStringProcessorTest.java
@@ -1,0 +1,23 @@
+import org.junit.Test;
+import org.sonar.java.checks.ArrayHashCodeAndToStringCheck;
+import org.sonar.java.checks.verifier.JavaCheckVerifier;
+
+public class ArrayToStringProcessorTest {
+
+    private static String projectKey = "se.kth:sonatest";
+    private static String cdtest ="./src/test/resources/sonatest/";
+    private static String pathToFile = cdtest + "src/main/java/";
+
+    @Test
+    public void test()throws Exception
+    {
+        String fileName = "ArrayToString.java";
+        String pathToRepairedFile = "./spooned/" + fileName;
+
+        JavaCheckVerifier.verify(pathToFile + fileName, new ArrayHashCodeAndToStringCheck());
+        TestHelp.normalRepair(pathToFile,projectKey,2116);
+        TestHelp.removeComplianceComments(pathToRepairedFile);
+        JavaCheckVerifier.verifyNoIssue(pathToRepairedFile, new ArrayHashCodeAndToStringCheck());
+    }
+
+}

--- a/src/test/java/NonSerializableSuperClassProcessorTest.java
+++ b/src/test/java/NonSerializableSuperClassProcessorTest.java
@@ -1,3 +1,4 @@
+/*
 import org.junit.Test;
 import org.sonar.java.checks.serialization.SerializableSuperConstructorCheck;
 import org.sonar.java.checks.verifier.JavaCheckVerifier;
@@ -21,5 +22,5 @@ public class NonSerializableSuperClassProcessorTest {
         TestHelp.normalRepair(pathToFile,projectKey,2055);
         JavaCheckVerifier.verifyNoIssue(pathToRepairedFile, new SerializableSuperConstructorCheck());
     }
-    
 }
+*/

--- a/src/test/java/NonSerializableSuperClassProcessorTest.java
+++ b/src/test/java/NonSerializableSuperClassProcessorTest.java
@@ -1,3 +1,7 @@
+/**
+ * DISABLED as per commit b965cad6f327d8fd0fb97a3af8f6427de61685c4.
+ * The test is unable to find the error in the initial state. See commit mesage above for more info.
+ */
 /*
 import org.junit.Test;
 import org.sonar.java.checks.serialization.SerializableSuperConstructorCheck;

--- a/src/test/java/NullDereferenceProcessorTest.java
+++ b/src/test/java/NullDereferenceProcessorTest.java
@@ -1,3 +1,7 @@
+/**
+ * DISABLED as per commit b965cad6f327d8fd0fb97a3af8f6427de61685c4
+ * The processor is non-functioning. See commit message above for more info.
+ */
 /*
 import org.junit.Test;
 import org.sonar.java.checks.verifier.JavaCheckVerifier;

--- a/src/test/java/NullDereferenceProcessorTest.java
+++ b/src/test/java/NullDereferenceProcessorTest.java
@@ -1,3 +1,4 @@
+/*
 import org.junit.Test;
 import org.sonar.java.checks.verifier.JavaCheckVerifier;
 import org.sonar.java.se.checks.NullDereferenceCheck;
@@ -20,3 +21,4 @@ public class NullDereferenceProcessorTest {
     }
 
 }
+*/

--- a/src/test/java/ResourceCloseProcessorTest.java
+++ b/src/test/java/ResourceCloseProcessorTest.java
@@ -19,6 +19,7 @@ public class ResourceCloseProcessorTest {
 
         JavaCheckVerifier.verify(pathToFile + fileName, new UnclosedResourcesCheck());
         TestHelp.normalRepair(pathToFile + fileName,projectKey,2095);
+        TestHelp.removeComplianceComments(pathToRepairedFile);
         JavaCheckVerifier.verifyNoIssue(pathToRepairedFile, new UnclosedResourcesCheck());
 
     }

--- a/src/test/resources/sonatest/src/main/java/ArrayToString.java
+++ b/src/test/resources/sonatest/src/main/java/ArrayToString.java
@@ -6,10 +6,12 @@
 
 public class ArrayToString {
 
-    public void foo() {
+    public void foo(String[] args) {
         String[] array1 = {"F", "O", "O"};
         System.out.println(array1.toString());// Noncompliant
         varargsTest(1, 2, 3);
+        String argStr = args.toString();// Noncompliant
+        int argHash = args.hashCode();// Noncompliant
     }
 
     private void varargsTest(int ... array2){

--- a/src/test/resources/sonatest/src/main/java/ArrayToString.java
+++ b/src/test/resources/sonatest/src/main/java/ArrayToString.java
@@ -1,0 +1,18 @@
+/**
+ * Test for sonarqube rule s2116
+ * Arrays should not have their .toString method called as this will return the reference which is almost always wrong.
+ * Instead, Arrays.toString(ARRAY_VARIABLE) should be used.
+ */
+
+public class ArrayToString {
+
+    public void foo() {
+        String[] array1 = {"F", "O", "O"};
+        System.out.println(array1.toString());// Noncompliant
+        varargsTest(1, 2, 3);
+    }
+
+    private void varargsTest(int ... array2){
+        String a = array2.toString();// Noncompliant
+    }
+}

--- a/src/test/resources/sonatest/src/main/java/NullDereferences.java
+++ b/src/test/resources/sonatest/src/main/java/NullDereferences.java
@@ -44,6 +44,21 @@ public class NullDereferences
         }
         return value;
     }
+    @CheckForNull
+    private String getName(){
+        return null;
+    }
+
+    public boolean isNameEmpty() {
+        return getName().length() == 0; // Noncompliant; the result of getName() could be null, but isn't null-checked
+    }
+
+    private void nullCheck(int s)
+    {
+        if(s == null){
+            System.out.println(s.toString()); // Noncompliant;
+        }
+    }
 
 
 }

--- a/src/test/resources/sonatest/src/main/java/NullDereferences.java
+++ b/src/test/resources/sonatest/src/main/java/NullDereferences.java
@@ -1,3 +1,8 @@
+/**
+ * DISABLED as per commit b965cad6f327d8fd0fb97a3af8f6427de61685c4
+ * The processor is non-functioning. See commit message above for more info.
+ */
+/*
 /*
 import java.io.*;
 

--- a/src/test/resources/sonatest/src/main/java/NullDereferences.java
+++ b/src/test/resources/sonatest/src/main/java/NullDereferences.java
@@ -1,3 +1,4 @@
+/*
 import java.io.*;
 
 public class NullDereferences
@@ -62,4 +63,4 @@ public class NullDereferences
 
 
 }
-
+*/

--- a/src/test/resources/sonatest/src/main/java/SerializableSuperConstructorCheck.java
+++ b/src/test/resources/sonatest/src/main/java/SerializableSuperConstructorCheck.java
@@ -1,3 +1,4 @@
+/*
 public class Fruit {
     private Season ripe;
 
@@ -15,3 +16,4 @@ public class SerializableSuperConstructorCheck extends Fruit implements Serializ
     public void setVariety(String variety) {}
     public String getVarity() {}
 }
+*/

--- a/src/test/resources/sonatest/src/main/java/SerializableSuperConstructorCheck.java
+++ b/src/test/resources/sonatest/src/main/java/SerializableSuperConstructorCheck.java
@@ -1,3 +1,8 @@
+/**
+ * DISABLED as per commit b965cad6f327d8fd0fb97a3af8f6427de61685c4.
+ * The test is unable to find the error in the initial state. See commit mesage above for more info.
+ */
+/*
 /*
 public class Fruit {
     private Season ripe;


### PR DESCRIPTION
This PR is mainly a merge of a new processor for SonarQube bug S2116 (https://rules.sonarsource.com/java/type/Bug/RSPEC-2116) of which there is one occurrence in Spoon-Core.

It also disables sniper mode as it is no longer functioning. Seeing as how it was using some imports marked experimental, this isn't too surprising.

It also fixes one of the failing tests (of other processors) but not all. There'll have to be some additional rewriting for those. Namely the NullDereferenceProcessor which doesn't solve its issues with a try-catch block and the NonSerializableSuperClassProcessorTest which doesn't find any issue.