### PR TITLE
Boxed equals proocessor

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -53,10 +53,12 @@
             <scope>test</scope>
         </dependency>
 
+        <!-- https://mvnrepository.com/artifact/org.sonarsource.java/sonar-java-plugin -->
         <dependency>
             <groupId>org.sonarsource.java</groupId>
             <artifactId>sonar-java-plugin</artifactId>
-            <version>5.7.0.15470</version>
+            <version>5.14.0.18788</version>
+            <scope>provided</scope>
         </dependency>
 
         <dependency>

--- a/src/main/java/BoxedTypesEqualsProcessor.java
+++ b/src/main/java/BoxedTypesEqualsProcessor.java
@@ -1,0 +1,30 @@
+import spoon.processing.AbstractProcessor;
+import spoon.reflect.code.CtCodeSnippetExpression;
+import spoon.reflect.code.CtExpression;
+import spoon.reflect.code.CtInvocation;
+import spoon.reflect.declaration.CtMethod;
+import spoon.reflect.declaration.CtType;
+import spoon.reflect.reference.CtExecutableReference;
+
+import java.util.Arrays;
+
+public class BoxedTypesEqualsProcessor extends AbstractProcessor<CtInvocation<?>> {
+
+    public BoxedTypesEqualsProcessor(String projectKey) throws Exception {
+        ParseAPI.parse(4973,"",projectKey);
+    }
+
+    @Override
+    public boolean isToBeProcessed(CtInvocation<?> candidate)
+    {
+        if(candidate==null||candidate.getTarget()==null)
+        {
+            return false;
+        }
+        return false;
+    }
+    @Override
+    public void process(CtInvocation<?> element) {
+        
+    }
+}

--- a/src/main/java/BoxedTypesEqualsProcessor.java
+++ b/src/main/java/BoxedTypesEqualsProcessor.java
@@ -32,12 +32,9 @@ public class BoxedTypesEqualsProcessor extends AbstractProcessor<CtElement> {
                 */
                 String nullType = getFactory().Code().createCodeSnippetExpression("").getType().NULL_TYPE_NAME;
                 if(!left.getType().isPrimitive() && !right.getType().isPrimitive() &&
+                        !left.getType().isEnum() && !right.getType().isEnum() &&
                         !left.getType().getSimpleName().equals(nullType) &&
-                        !right.getType().getSimpleName().equals(nullType) &&
-                        !left.getType().getSimpleName().equals("CommentType") &&
-                        !right.getType().getSimpleName().equals("CommentType") &&
-                        !left.toString().equals("CtRole.COMMENT") &&
-                        !right.toString().equals("CtRole.COMMENT")){
+                        !right.getType().getSimpleName().equals(nullType)){
                     return true;
                 }
             }

--- a/src/main/java/BoxedTypesEqualsProcessor.java
+++ b/src/main/java/BoxedTypesEqualsProcessor.java
@@ -21,10 +21,9 @@ public class BoxedTypesEqualsProcessor extends AbstractProcessor<CtElement> {
         }
         if (candidate instanceof CtBinaryOperator){
             CtBinaryOperator op = (CtBinaryOperator)candidate;
-            if(op.getKind() == BinaryOperatorKind.EQ){
+            if(op.getKind() == BinaryOperatorKind.EQ || op.getKind() == BinaryOperatorKind.NE){
                 CtExpression left = op.getLeftHandOperand();
                 CtExpression right = op.getRightHandOperand();
-
                 /*
                 The reason we don't check for the case where one variable is boxed is because Java implicitly unboxes
                 the boxed type to primitive, making the == check fine. See JLS #5.6.2:
@@ -44,8 +43,12 @@ public class BoxedTypesEqualsProcessor extends AbstractProcessor<CtElement> {
     @Override
     public void process(CtElement element) {
         CtBinaryOperator bo = (CtBinaryOperator)element;
+        String negation = "";
+        if(((CtBinaryOperator) element).getKind() == BinaryOperatorKind.NE){
+            negation = "!";
+        }
         CtCodeSnippetExpression newBinaryOperator = getFactory().Code().createCodeSnippetExpression(
-                bo.getLeftHandOperand().toString() + ".equals(" + bo.getRightHandOperand() + ")");
+                negation + bo.getLeftHandOperand().toString() + ".equals(" + bo.getRightHandOperand() + ")");
         bo.replace(newBinaryOperator);
     }
 }

--- a/src/main/java/BoxedTypesEqualsProcessor.java
+++ b/src/main/java/BoxedTypesEqualsProcessor.java
@@ -29,7 +29,7 @@ public class BoxedTypesEqualsProcessor extends AbstractProcessor<CtElement> {
                 the boxed type to primitive, making the == check fine. See JLS #5.6.2:
                 https://docs.oracle.com/javase/specs/jls/se8/html/jls-5.html#jls-5.6.2
                 */
-                String nullType = getFactory().Code().createCodeSnippetExpression("").getType().NULL_TYPE_NAME;
+                String nullType = getFactory().Type().NULL_TYPE.getQualifiedName();
                 if(!left.getType().isPrimitive() && !right.getType().isPrimitive() &&
                         !left.getType().isEnum() && !right.getType().isEnum() &&
                         !left.getType().getSimpleName().equals(nullType) &&

--- a/src/main/java/BoxedTypesEqualsProcessor.java
+++ b/src/main/java/BoxedTypesEqualsProcessor.java
@@ -33,7 +33,11 @@ public class BoxedTypesEqualsProcessor extends AbstractProcessor<CtElement> {
                 String nullType = getFactory().Code().createCodeSnippetExpression("").getType().NULL_TYPE_NAME;
                 if(!left.getType().isPrimitive() && !right.getType().isPrimitive() &&
                         !left.getType().getSimpleName().equals(nullType) &&
-                        !right.getType().getSimpleName().equals(nullType)){
+                        !right.getType().getSimpleName().equals(nullType) &&
+                        !left.getType().getSimpleName().equals("CommentType") &&
+                        !right.getType().getSimpleName().equals("CommentType") &&
+                        !left.toString().equals("CtRole.COMMENT") &&
+                        !right.toString().equals("CtRole.COMMENT")){
                     return true;
                 }
             }

--- a/src/main/java/BoxedTypesEqualsProcessor.java
+++ b/src/main/java/BoxedTypesEqualsProcessor.java
@@ -29,8 +29,11 @@ public class BoxedTypesEqualsProcessor extends AbstractProcessor<CtElement> {
                 The reason we don't check for the case where one variable is boxed is because Java implicitly unboxes
                 the boxed type to primitive, making the == check fine. See JLS #5.6.2:
                 https://docs.oracle.com/javase/specs/jls/se8/html/jls-5.html#jls-5.6.2
-                 */
-                if(!left.getType().isPrimitive() && !right.getType().isPrimitive()){
+                */
+                String nullType = getFactory().Code().createCodeSnippetExpression("").getType().NULL_TYPE_NAME;
+                if(!left.getType().isPrimitive() && !right.getType().isPrimitive() &&
+                        !left.getType().getSimpleName().equals(nullType) &&
+                        !right.getType().getSimpleName().equals(nullType)){
                     return true;
                 }
             }

--- a/src/main/java/BoxedTypesEqualsProcessor.java
+++ b/src/main/java/BoxedTypesEqualsProcessor.java
@@ -1,30 +1,60 @@
 import spoon.processing.AbstractProcessor;
 import spoon.reflect.code.CtCodeSnippetExpression;
 import spoon.reflect.code.CtExpression;
-import spoon.reflect.code.CtInvocation;
+import spoon.reflect.declaration.CtElement;
+import spoon.reflect.code.BinaryOperatorKind;
+import spoon.reflect.code.CtBinaryOperator;
 import spoon.reflect.declaration.CtMethod;
 import spoon.reflect.declaration.CtType;
-import spoon.reflect.reference.CtExecutableReference;
 
 import java.util.Arrays;
 
-public class BoxedTypesEqualsProcessor extends AbstractProcessor<CtInvocation<?>> {
+public class BoxedTypesEqualsProcessor extends AbstractProcessor<CtElement> {
 
     public BoxedTypesEqualsProcessor(String projectKey) throws Exception {
         ParseAPI.parse(4973,"",projectKey);
     }
 
     @Override
-    public boolean isToBeProcessed(CtInvocation<?> candidate)
+
+    public boolean isToBeProcessed(CtElement candidate)
     {
-        if(candidate==null||candidate.getTarget()==null)
+        if(candidate==null)
         {
             return false;
+        }
+        if (candidate instanceof CtBinaryOperator){
+            CtBinaryOperator op = (CtBinaryOperator)candidate;
+            if(op.getKind() == BinaryOperatorKind.EQ){
+                CtExpression left = op.getLeftHandOperand();
+                CtExpression right = op.getRightHandOperand();
+                /*
+                Boxing boxed types returns the same type.
+                The reason we don't check for the case where one variable is boxed is because Java implicitly unboxes
+                the boxed type to primitive, making the == check fine. See JLS #5.6.2:
+                https://docs.oracle.com/javase/specs/jls/se8/html/jls-5.html#jls-5.6.2
+                 */
+                if(left.getType().box() == left.getType() && right.getType().box() == right.getType()){
+                    return true;
+                }
+            }
         }
         return false;
     }
     @Override
-    public void process(CtInvocation<?> element) {
-        
+    public void process(CtElement element) {
+        CtBinaryOperator binaryOperator = (CtBinaryOperator)element;
+        // System.out.println(binaryOperator.getLeftHandOperand().getType().getTypeDeclaration().getMethodsByName("equals").get(0)); // String
+        // System.out.println(binaryOperator.getLeftHandOperand().getType().getClass()); // class spoon.support.reflect.reference.CtTypeReferenceImpl
+        // CtType leftClass = getFactory().Type().STRING.getTypeDeclaration();
+        // CtMethod leftMethod = (CtMethod) binaryOperator.getLeftHandOperand().getType().getTypeDeclaration().getMethodsByName("equals").get(0);
+        CtCodeSnippetExpression newBinaryOperator = getFactory().Code().createCodeSnippetExpression(binaryOperator.getLeftHandOperand().toString() + ".equals(" + binaryOperator.getRightHandOperand() + ");");
+        // System.out.println(newBinaryOperator);
+        binaryOperator.replace(newBinaryOperator);
+        // CtType leftClass = getFactory().Class().get(binaryOperator.getLeftHandOperand().getType().class);
+        // CtMethod method = null;
+        // method = (CtMethod) leftClass.getMethodsByName("equals").get(0);
+        // System.out.println(leftClass);
+        // System.out.println(leftMethod);
     }
 }

--- a/src/main/java/BoxedTypesEqualsProcessor.java
+++ b/src/main/java/BoxedTypesEqualsProcessor.java
@@ -4,10 +4,6 @@ import spoon.reflect.code.CtExpression;
 import spoon.reflect.declaration.CtElement;
 import spoon.reflect.code.BinaryOperatorKind;
 import spoon.reflect.code.CtBinaryOperator;
-import spoon.reflect.declaration.CtMethod;
-import spoon.reflect.declaration.CtType;
-
-import java.util.Arrays;
 
 public class BoxedTypesEqualsProcessor extends AbstractProcessor<CtElement> {
 
@@ -28,13 +24,13 @@ public class BoxedTypesEqualsProcessor extends AbstractProcessor<CtElement> {
             if(op.getKind() == BinaryOperatorKind.EQ){
                 CtExpression left = op.getLeftHandOperand();
                 CtExpression right = op.getRightHandOperand();
+
                 /*
-                Boxing boxed types returns the same type.
                 The reason we don't check for the case where one variable is boxed is because Java implicitly unboxes
                 the boxed type to primitive, making the == check fine. See JLS #5.6.2:
                 https://docs.oracle.com/javase/specs/jls/se8/html/jls-5.html#jls-5.6.2
                  */
-                if(left.getType().box() == left.getType() && right.getType().box() == right.getType()){
+                if(!left.getType().isPrimitive() && !right.getType().isPrimitive()){
                     return true;
                 }
             }
@@ -43,18 +39,9 @@ public class BoxedTypesEqualsProcessor extends AbstractProcessor<CtElement> {
     }
     @Override
     public void process(CtElement element) {
-        CtBinaryOperator binaryOperator = (CtBinaryOperator)element;
-        // System.out.println(binaryOperator.getLeftHandOperand().getType().getTypeDeclaration().getMethodsByName("equals").get(0)); // String
-        // System.out.println(binaryOperator.getLeftHandOperand().getType().getClass()); // class spoon.support.reflect.reference.CtTypeReferenceImpl
-        // CtType leftClass = getFactory().Type().STRING.getTypeDeclaration();
-        // CtMethod leftMethod = (CtMethod) binaryOperator.getLeftHandOperand().getType().getTypeDeclaration().getMethodsByName("equals").get(0);
-        CtCodeSnippetExpression newBinaryOperator = getFactory().Code().createCodeSnippetExpression(binaryOperator.getLeftHandOperand().toString() + ".equals(" + binaryOperator.getRightHandOperand() + ");");
-        // System.out.println(newBinaryOperator);
-        binaryOperator.replace(newBinaryOperator);
-        // CtType leftClass = getFactory().Class().get(binaryOperator.getLeftHandOperand().getType().class);
-        // CtMethod method = null;
-        // method = (CtMethod) leftClass.getMethodsByName("equals").get(0);
-        // System.out.println(leftClass);
-        // System.out.println(leftMethod);
+        CtBinaryOperator bo = (CtBinaryOperator)element;
+        CtCodeSnippetExpression newBinaryOperator = getFactory().Code().createCodeSnippetExpression(
+                bo.getLeftHandOperand().toString() + ".equals(" + bo.getRightHandOperand() + ");");
+        bo.replace(newBinaryOperator);
     }
 }

--- a/src/main/java/BoxedTypesEqualsProcessor.java
+++ b/src/main/java/BoxedTypesEqualsProcessor.java
@@ -41,7 +41,7 @@ public class BoxedTypesEqualsProcessor extends AbstractProcessor<CtElement> {
     public void process(CtElement element) {
         CtBinaryOperator bo = (CtBinaryOperator)element;
         CtCodeSnippetExpression newBinaryOperator = getFactory().Code().createCodeSnippetExpression(
-                bo.getLeftHandOperand().toString() + ".equals(" + bo.getRightHandOperand() + ");");
+                bo.getLeftHandOperand().toString() + ".equals(" + bo.getRightHandOperand() + ")");
         bo.replace(newBinaryOperator);
     }
 }

--- a/src/main/java/TestHelp.java
+++ b/src/main/java/TestHelp.java
@@ -23,6 +23,7 @@ public class TestHelp {
         // rule.putIfAbsent(2055, NonSerializableSuperClassProcessor.class);
         rule.putIfAbsent(2095, ResourceCloseProcessor.class);
         rule.putIfAbsent(2116, ArrayToStringProcessor.class);
+        rule.putIfAbsent(4973, BoxedTypesEqualsProcessor.class);
         // rule.putIfAbsent(2259, NullDereferenceProcessor.class);
     }
 

--- a/src/test/java/BoxedTypesEqualsProcessorTest.java
+++ b/src/test/java/BoxedTypesEqualsProcessorTest.java
@@ -1,0 +1,23 @@
+import org.junit.Test;
+import org.sonar.java.checks.CompareStringsBoxedTypesWithEqualsCheck;
+import org.sonar.java.checks.verifier.JavaCheckVerifier;
+
+public class BoxedTypesEqualsProcessorTest {
+
+    private static String projectKey = "se.kth:sonatest";
+    private static String cdtest ="./src/test/resources/sonatest/";
+    private static String pathToFile = cdtest + "src/main/java/";
+
+    @Test
+    public void test()throws Exception
+    {
+        String fileName = "BoxedTypesEquals.java";
+        String pathToRepairedFile = "./spooned/" + fileName;
+
+        JavaCheckVerifier.verify(pathToFile + fileName, new CompareStringsBoxedTypesWithEqualsCheck());
+        TestHelp.normalRepair(pathToFile,projectKey,4973);
+        TestHelp.removeComplianceComments(pathToRepairedFile);
+        JavaCheckVerifier.verifyNoIssue(pathToRepairedFile, new CompareStringsBoxedTypesWithEqualsCheck());
+    }
+
+}

--- a/src/test/resources/sonatest/src/main/java/BoxedTypesEquals.java
+++ b/src/test/resources/sonatest/src/main/java/BoxedTypesEquals.java
@@ -1,0 +1,20 @@
+/**
+ * Test for sonarqube rule s4973
+ * Boxed types should be compared with equals() rather than "==" since equals compares values while
+ * "==" compares memory location.
+ */
+
+public class BoxedTypesEquals {
+
+    private String getFirstName(){
+        return new String("John");
+    }
+
+    private String getLastName(){
+        return new String("John");
+    }
+
+    String firstName = getFirstName(); // String overrides equals
+    String lastName = getLastName();
+    boolean x = (firstName == lastName);// Noncompliant
+}

--- a/src/test/resources/sonatest/src/main/java/BoxedTypesEquals.java
+++ b/src/test/resources/sonatest/src/main/java/BoxedTypesEquals.java
@@ -6,16 +6,34 @@
 
 public class BoxedTypesEquals {
 
-    public void foo(){
-        String firstName = getFirstName(); // String overrides equals
-        String lastName = getLastName();
-        boolean eq = (firstName == lastName);// Noncompliant
+    boolean eq = true;
+
+    // Java implicitly converts one variable to primitive if something boxed and primitive is compared.
+    private void mixedCompare(){
+        int e = 4;
+        Integer f = 4;
+        eq = (e == f);// Compliant;
+    }
+
+    // Integer is not primitive and should use .equals()
+    private boolean IntegerCompare(){
+        Integer a = 5;
+        Integer b = 5;
+        return b == a;// Noncompliant
+    }
+
+    // Int is primitive and can use ==
+    private void intCompare(){
         int x = 5;
         int y = 5;
-        eq = (x == y); // Compliant; Non-boxed variables
-        /*
-        Add a custom type equality check which overrides the equals() method
-         */
+        eq = (x == y); // Compliant;
+    }
+
+    // String is not primitive and should use .equals()
+    private void stringCompare(){
+        String firstName = getFirstName(); // String overrides equals
+        String lastName = getLastName();
+        eq = (firstName == lastName);// Noncompliant
     }
 
     private String getFirstName(){

--- a/src/test/resources/sonatest/src/main/java/BoxedTypesEquals.java
+++ b/src/test/resources/sonatest/src/main/java/BoxedTypesEquals.java
@@ -13,6 +13,7 @@ public class BoxedTypesEquals {
         int e = 4;
         Integer f = 4;
         eq = (e == f);// Compliant;
+        eq = (f == e);// Compliant;
     }
 
     // Integer is not primitive and should use .equals()
@@ -27,6 +28,25 @@ public class BoxedTypesEquals {
         int x = 5;
         int y = 5;
         eq = (x == y); // Compliant;
+        eq = (y == x); // Compliant;
+    }
+
+    // Null comparisons are excluded from transformation
+    private void nullCompare(){
+        String x = null;
+        eq = (x == null); // Compliant
+        eq = (null == x); // Compliant
+    }
+
+    // ENUM comparisons are excluded from transformation
+    private void nullCompare(){
+        enum foo {
+            BAR,
+            XOR
+        }
+        foo x = foo.BAR;
+        eq = (x == foo.BAR); // Compliant
+        eq = (foo.XOR == x); // Compliant
     }
 
     // String is not primitive and should use .equals()

--- a/src/test/resources/sonatest/src/main/java/BoxedTypesEquals.java
+++ b/src/test/resources/sonatest/src/main/java/BoxedTypesEquals.java
@@ -6,6 +6,18 @@
 
 public class BoxedTypesEquals {
 
+    public void foo(){
+        String firstName = getFirstName(); // String overrides equals
+        String lastName = getLastName();
+        boolean eq = (firstName == lastName);// Noncompliant
+        int x = 5;
+        int y = 5;
+        eq = (x == y); // Compliant; Non-boxed variables
+        /*
+        Add a custom type equality check which overrides the equals() method
+         */
+    }
+
     private String getFirstName(){
         return new String("John");
     }
@@ -13,8 +25,4 @@ public class BoxedTypesEquals {
     private String getLastName(){
         return new String("John");
     }
-
-    String firstName = getFirstName(); // String overrides equals
-    String lastName = getLastName();
-    boolean x = (firstName == lastName);// Noncompliant
 }

--- a/src/test/resources/sonatest/src/main/java/BoxedTypesEquals.java
+++ b/src/test/resources/sonatest/src/main/java/BoxedTypesEquals.java
@@ -12,7 +12,7 @@ public class BoxedTypesEquals {
     private void mixedCompare(){
         int e = 4;
         Integer f = 4;
-        eq = (e == f);// Compliant;
+        eq = (e != f);// Compliant;
         eq = (f == e);// Compliant;
     }
 
@@ -20,7 +20,7 @@ public class BoxedTypesEquals {
     private boolean IntegerCompare(){
         Integer a = 5;
         Integer b = 5;
-        return b == a;// Noncompliant
+        return b != a;// Noncompliant
     }
 
     // Int is primitive and can use ==

--- a/src/test/resources/sonatest/src/main/java/BoxedTypesEquals.java
+++ b/src/test/resources/sonatest/src/main/java/BoxedTypesEquals.java
@@ -30,10 +30,13 @@ public class BoxedTypesEquals {
     }
 
     // String is not primitive and should use .equals()
-    private void stringCompare(){
+    private boolean stringCompare(){
         String firstName = getFirstName(); // String overrides equals
         String lastName = getLastName();
-        eq = (firstName == lastName);// Noncompliant
+        if(firstName == lastName){// Noncompliant
+            return true;
+        }
+        return false;
     }
 
     private String getFirstName(){


### PR DESCRIPTION
Processor for fixing Sonarqube violation S4973, using == instead of .equals() when comparing boxed types.