### PR TITLE
WIP:Failing old processor and test case

### DIFF
--- a/src/main/java/NonSerializableSuperClassProcessor.java
+++ b/src/main/java/NonSerializableSuperClassProcessor.java
@@ -2,8 +2,6 @@
  * DISABLED as per commit b965cad6f327d8fd0fb97a3af8f6427de61685c4.
  * The test is unable to find the error in the initial state. See commit message above for more info.
  */
-/*
-/*
 import org.json.JSONArray;
 import org.json.JSONException;
 import spoon.processing.AbstractProcessor;
@@ -27,7 +25,7 @@ public class NonSerializableSuperClassProcessor extends AbstractProcessor<CtClas
     private String thisBugName;        //name (message) of current thisBug.
     private static int inp=-1;
     private static boolean defolt = false;
-    public NonSerializableSuperClassProcessor(String projectKey,boolean defolt1) throws Exception {
+    public NonSerializableSuperClassProcessor(String projectKey) throws Exception {
         jsonArray= ParseAPI.parse(2055,"",projectKey);
         SetOfBugs = Bug.createSetOfBugs(this.jsonArray);
         SetOfLineNumbers=new HashSet<Long>();
@@ -38,7 +36,7 @@ public class NonSerializableSuperClassProcessor extends AbstractProcessor<CtClas
             SetOfLineNumbers.add(bug.getLineNumber());
             SetOfFileNames.add(bug.getFileName());
         }
-        if(!defolt1)
+        if(!true == true)
         {
             Scanner sc = new Scanner(System.in);
             String message = String.format("There are two possible repair for this bug." +
@@ -156,4 +154,3 @@ public class NonSerializableSuperClassProcessor extends AbstractProcessor<CtClas
         }
     }
 }
-*/

--- a/src/main/java/TestHelp.java
+++ b/src/main/java/TestHelp.java
@@ -18,7 +18,7 @@ public class TestHelp {
         rule = new HashMap<>();
         rule.putIfAbsent(1854, DeadStoreProcessor.class);
         rule.putIfAbsent(1948, SerializableFieldProcessor.class);
-        // rule.putIfAbsent(2055, NonSerializableSuperClassProcessor.class);
+        rule.putIfAbsent(2055, NonSerializableSuperClassProcessor.class);
         rule.putIfAbsent(2095, ResourceCloseProcessor.class);
         rule.putIfAbsent(2111, BigDecimalDoubleConstructorProcessor.class);
         rule.putIfAbsent(2116, ArrayToStringProcessor.class);

--- a/src/test/java/NonSerializableSuperClassProcessorTest.java
+++ b/src/test/java/NonSerializableSuperClassProcessorTest.java
@@ -2,7 +2,7 @@
  * DISABLED as per commit b965cad6f327d8fd0fb97a3af8f6427de61685c4.
  * The test is unable to find the error in the initial state. See commit mesage above for more info.
  */
-/*
+
 import org.junit.Test;
 import org.sonar.java.checks.serialization.SerializableSuperConstructorCheck;
 import org.sonar.java.checks.verifier.JavaCheckVerifier;
@@ -23,8 +23,9 @@ public class NonSerializableSuperClassProcessorTest {
         String pathToRepairedFile = "./spooned/" + fileName;
 
         JavaCheckVerifier.verify(pathToFile + fileName,new SerializableSuperConstructorCheck());
-        TestHelp.normalRepair(pathToFile,projectKey,2055);
+        TestHelp.repair(pathToFile,projectKey,2055);
+        TestHelp.removeComplianceComments(pathToRepairedFile);
         JavaCheckVerifier.verifyNoIssue(pathToRepairedFile, new SerializableSuperConstructorCheck());
     }
 }
-*/
+

--- a/src/test/resources/sonatest/src/main/java/SerializableSuperConstructorCheck.java
+++ b/src/test/resources/sonatest/src/main/java/SerializableSuperConstructorCheck.java
@@ -1,24 +1,21 @@
-/**
- * DISABLED as per commit b965cad6f327d8fd0fb97a3af8f6427de61685c4.
- * The test is unable to find the error in the initial state. See commit mesage above for more info.
- */
-/*
-/*
-public class Fruit {
-    private Season ripe;
-
-    public Fruit (Season ripe) {}
-    public void setRipe(Season ripe) {}
-    public Season getRipe() {}
-}
-
-public class SerializableSuperConstructorCheck extends Fruit implements Serializable {  // Noncompliant; nonserializable ancestor doesn't have no-arg constructor
-    private static final long serialVersionUID = 1;
-
+import java.io.Serializable;
+public class SerializableSuperConstructorCheck extends Fruit implements Serializable {  // Noncompliant
     private String variety;
 
-    public SerializableSuperConstructorCheck(Season ripe, String variety) { }
-    public void setVariety(String variety) {}
-    public String getVarity() {}
+    public SerializableSuperConstructorCheck(String ripe, String variety) {
+    }
+
+    public void setVariety(String variety) {
+    }
+
+    public String getVarity() {
+    }
 }
-*/
+
+public class Fruit {
+    private String ripe;
+
+    public Fruit (String ripe) {}
+    public void setRipe(String ripe) {}
+    public String getRipe() {}
+}


### PR DESCRIPTION
This is an old implementation of a processor for Sonarqube rule S2055 with a failing test case.
It is recommended that an attempt at fixing it changes the filter to use Spoon rather than the Sonarjava plugin.
For examples of this, look at other processors of type BUG (except S2095).