### PR TITLE
Fix removal of compliance comments for testing purposes.

### DIFF
--- a/src/main/java/TestHelp.java
+++ b/src/main/java/TestHelp.java
@@ -87,7 +87,7 @@ public class TestHelp {
             while ((line = file.readLine()) != null) {
                 if(line.contains(complianceComment)){
                     line.trim();
-                    line = line.substring(0, line.length() - (complianceComment.length()));
+                    line = line.substring(0, line.indexOf(complianceComment));
                 }
                 inputBuffer.append(line+'\n');
             }


### PR DESCRIPTION
For testing, we need to insert the comment `// Noncompliant` in lines where there are rule violations (this is mandatory according to Sonar).

We have a method that removes this comment from the source code after Sonarqube-repair repairs it. However, this method only works properly when we have the simple comment `// Noncompliant`, and test cases fail when we have a "bigger" comment like `// Noncompliant {{Cast one of the operands of this addition operation to a "long".}}`. This PR proposes a fix for that.