### PR TITLE
Add a summary of handled rules

### DIFF
--- a/docs/HANDLED_SONARQUBE_RULES.md
+++ b/docs/HANDLED_SONARQUBE_RULES.md
@@ -1,8 +1,18 @@
 ## Handled SonarQube rules
 
-Sonarqube-repair can currently repair violations of 7 SonarQube rules of which 5 are labeled as `BUG` and 2 as `Code Smell`.
+Sonarqube-repair can currently repair violations of 7 SonarQube rules of which 5 are labeled as `Bug` and 2 as `Code Smell`:
 
-### *BUG*
+* [Bug](HANDLED_SONARQUBE_RULES.md#*Bug*)
+    * [Resources should be closed](HANDLED_SONARQUBE_RULES.md#resources-should-be-closed-sonar-rule-2095httpsrulessonarsourcecomjavarspec-2095) ([Sonar Rule 2095](https://rules.sonarsource.com/java/RSPEC-2095))
+    * ["BigDecimal(double)" should not be used](HANDLED_SONARQUBE_RULES.md#bigdecimaldouble-should-not-be-used-sonar-rule-2111httpsrulessonarsourcecomjavarspec-2111) ([Sonar Rule 2111](https://rules.sonarsource.com/java/RSPEC-2111))
+    * ["hashCode" and "toString" should not be called on array instances](HANDLED_SONARQUBE_RULES.md#hashcode-and-tostring-should-not-be-called-on-array-instances-sonar-rule-2116httpsrulessonarsourcecomjavarspec-2116) ([Sonar Rule 2116](https://rules.sonarsource.com/java/RSPEC-2116))
+    * ["Iterator.next()" methods should throw "NoSuchElementException"](HANDLED_SONARQUBE_RULES.md#iteratornext-methods-should-throw-nosuchelementexception-sonar-rule-2272httpsrulessonarsourcecomjavarspec-2272) ([Sonar Rule 2272](https://rules.sonarsource.com/java/RSPEC-2272))
+    * [Strings and Boxed types should be compared using "equals()"](HANDLED_SONARQUBE_RULES.md#strings-and-boxed-types-should-be-compared-using-equals-sonar-rule-4973httpsrulessonarsourcecomjavarspec-4973) ([Sonar Rule 4973](https://rules.sonarsource.com/java/RSPEC-4973))
+* [Code Smell](HANDLED_SONARQUBE_RULES.md#*Code Smell*)
+    * [Unused assignments should be removed](HANDLED_SONARQUBE_RULES.md#unused-assignments-should-be-removed-sonar-rule-1854httpsrulessonarsourcecomjavarspec-1854) ([Sonar Rule 1854](https://rules.sonarsource.com/java/RSPEC-1854))
+    * [Fields in a "Serializable" class should either be transient or serializable](HANDLED_SONARQUBE_RULES.md#fields-in-a-serializable-class-should-either-be-transient-or-serializable-sonar-rule-1948httpsrulessonarsourcecomjavarspec-1948) ([Sonar Rule 1948](https://rules.sonarsource.com/java/RSPEC-1948))
+
+### *Bug*
 
 #### Resources should be closed ([Sonar Rule 2095](https://rules.sonarsource.com/java/RSPEC-2095))
 
@@ -46,7 +56,7 @@ Check out an accepted PR in [Apache PDFBox](https://github.com/apache/pdfbox/pul
 
 -----
 
-#### "HashCode" and "toString" should not be called on array instances ([Sonar Rule 2116](https://rules.sonarsource.com/java/RSPEC-2116))
+#### "hashCode" and "toString" should not be called on array instances ([Sonar Rule 2116](https://rules.sonarsource.com/java/RSPEC-2116))
 
 Any invocation of `toString()` or `hashCode()` on an array is replaced with `Arrays.toString(parameter)` or `Arrays.hashCode(parameter)`.
 
@@ -103,7 +113,7 @@ Check out an accepted PR in [Apache Sling Discovery](https://github.com/apache/s
 
 ### *Code Smell*
 
-#### Dead Stores should be removed ([Sonar Rule 1854](https://rules.sonarsource.com/java/RSPEC-1854))
+#### Unused assignments should be removed ([Sonar Rule 1854](https://rules.sonarsource.com/java/RSPEC-1854))
 
 The repair consists of deleting useless assignments.
 
@@ -126,7 +136,7 @@ Check out an accepted PR in [Spoon](https://github.com/INRIA/spoon/pull/2265) th
 
 ------
 
-#### Fields in a "Serializable" class should be serializable ([Sonar Rule 1948](https://rules.sonarsource.com/java/RSPEC-1948))
+#### Fields in a "Serializable" class should either be transient or serializable ([Sonar Rule 1948](https://rules.sonarsource.com/java/RSPEC-1948))
 
 The repair adds the modifier `transient` to all non-serializable
 fields. In the future, the plan is to give user the option if they want to go to the class


### PR DESCRIPTION
This PR adds a summary (i.e., a table of contents) of handled rules in `docs/HANDLED_SONARQUBE_RULES.md`.