### PR TITLE
Refactor Sonar-Web-API-based processors

### DIFF
--- a/docs/HANDLED_SONARQUBE_RULES.md
+++ b/docs/HANDLED_SONARQUBE_RULES.md
@@ -18,9 +18,8 @@ Example:
 +            try (ZipInputStream zipInput = new ZipInputStream(new BufferedInputStream(new FileInputStream(file)))) {
                  ZipEntry entry;
 ...
-             zipInput.close();
--            } catch (Exception e) {
--                Launcher.LOGGER.error(e.getMessage(), e);
+             } catch (Exception e) {
+                 Launcher.LOGGER.error(e.getMessage(), e);
              }
 ```
 

--- a/src/main/java/sonarquberepair/processor/sonarbased/Bug.java
+++ b/src/main/java/sonarquberepair/processor/sonarbased/Bug.java
@@ -11,7 +11,8 @@ public class Bug {
 
 	private JSONObject jsonObject;
 	private JSONArray locations;
-	private long lineNumber;
+	private String ruleName;
+	private int lineNumber;
 	private String name;
 	private String fileName;
 
@@ -32,8 +33,9 @@ public class Bug {
 		if (flow.length() > 0) {
 			locations = flow.getJSONObject(0).getJSONArray("locations");
 		}
+		ruleName = (String) jsonObject.get("rule");
 		if (jsonObject.has("line")) {
-			lineNumber = (long) (int) (jsonObject.get("line")); //cast first to int then to long
+			lineNumber = (int) (jsonObject.get("line"));
 		}
 		name = (String) jsonObject.get("message");
 		String[] split = jsonObject.get("component").toString().split("/");
@@ -87,7 +89,11 @@ public class Bug {
 		return name;
 	}
 
-	public long getLineNumber() {
+	public int getRuleKey() {
+		return Integer.parseInt(ruleName.replace("java:S", ""));
+	}
+
+	public int getLineNumber() {
 		return lineNumber;
 	}
 

--- a/src/main/java/sonarquberepair/processor/sonarbased/Bug.java
+++ b/src/main/java/sonarquberepair/processor/sonarbased/Bug.java
@@ -10,36 +10,30 @@ import java.util.Set;
 public class Bug {
 
 	private JSONObject jsonObject;
-	private JSONArray locations;
 	private String ruleName;
 	private int lineNumber;
-	private String name;
 	private String fileName;
-
-	public Bug() {}
 
 	public Bug(JSONObject jsonObject) {
 		this.jsonObject = jsonObject;
-		init();
-	}
-
-	public Bug(Bug bug) {
-		this.jsonObject = bug.jsonObject;
-		init();
-	}
-
-	private void init() {
-		JSONArray flow = jsonObject.getJSONArray("flows");
-		if (flow.length() > 0) {
-			locations = flow.getJSONObject(0).getJSONArray("locations");
-		}
 		ruleName = (String) jsonObject.get("rule");
 		if (jsonObject.has("line")) {
 			lineNumber = (int) (jsonObject.get("line"));
 		}
-		name = (String) jsonObject.get("message");
 		String[] split = jsonObject.get("component").toString().split("/");
 		fileName = split[split.length - 1];
+	}
+
+	public int getRuleKey() {
+		return Integer.parseInt(ruleName.replace("java:S", ""));
+	}
+
+	public int getLineNumber() {
+		return lineNumber;
+	}
+
+	public String getFileName() {
+		return fileName;
 	}
 
 	@Override
@@ -65,7 +59,7 @@ public class Bug {
 			throw new Exception("null JSONArray passed to createSetOfBugs()");
 		}
 		for (int i = 0; i < jsonArray.length(); ++i) {
-			JSONObject obj = null;
+			JSONObject obj;
 			try {
 				obj = jsonArray.getJSONObject(i);
 				Bug bug = new Bug(obj);
@@ -75,44 +69,6 @@ public class Bug {
 			}
 		}
 		return setOfBugs;
-	}
-
-	public JSONObject getJsonObject() {
-		return jsonObject;
-	}
-
-	public JSONArray getLocations() {
-		return locations;
-	}
-
-	public String getName() {
-		return name;
-	}
-
-	public int getRuleKey() {
-		return Integer.parseInt(ruleName.replace("java:S", ""));
-	}
-
-	public int getLineNumber() {
-		return lineNumber;
-	}
-
-	public String getFileName() {
-		return fileName;
-	}
-
-	public void printBugLocations() {
-		try {
-			if (locations != null) {
-				for (int i = 0; i < locations.length(); ++i) {
-					System.out.println(locations.getJSONObject(i));
-				}
-			} else {
-				System.out.println("null locations");
-			}
-		} catch (JSONException e) {
-			e.printStackTrace();
-		}
 	}
 
 }

--- a/src/main/java/sonarquberepair/processor/sonarbased/DeadStoreProcessor.java
+++ b/src/main/java/sonarquberepair/processor/sonarbased/DeadStoreProcessor.java
@@ -1,6 +1,5 @@
 package sonarquberepair.processor.sonarbased;
 
-import org.json.JSONException;
 import spoon.reflect.code.CtAssignment;
 import spoon.reflect.code.CtCodeSnippetStatement;
 import spoon.reflect.code.CtLocalVariable;
@@ -19,51 +18,10 @@ public class DeadStoreProcessor extends SonarWebAPIBasedProcessor<CtStatement> {
 		if (element == null) {
 			return false;
 		}
-		long line = -1;
-		String targetName = "", fileOfElement = "";
-		if (element instanceof CtLocalVariable) {
-			targetName = ((CtLocalVariable) element).getSimpleName();
-			line = (long) element.getPosition().getLine();
-			String split1[] = element.getPosition().getFile().toString().split("/");
-			fileOfElement = split1[split1.length - 1];
-		} else if (element instanceof CtAssignment) {
-			targetName = ((CtAssignment) element).getAssigned().toString();
-			line = (long) element.getPosition().getLine();
-			String split1[] = element.getPosition().getFile().toString().split("/");
-			fileOfElement = split1[split1.length - 1];
-		} else {
+		if (!(element instanceof CtLocalVariable) && !(element instanceof CtAssignment)) {
 			return false;
 		}
-		if (!setOfLineNumbers.contains(line) || !setOfFileNames.contains(fileOfElement)) {
-			return false;
-		}
-		try {
-			thisBug = new Bug();
-		} catch (Exception e) {
-			e.printStackTrace();
-		}
-
-		for (Bug bug : setOfBugs) {
-			if (bug.getLineNumber() != line || !bug.getFileName().equals(fileOfElement)) {
-				continue;
-			}
-
-			String bugName = bug.getName();
-			String[] split = bugName.split("\"");
-			for (String bugWord : split) {
-				if (targetName.equals(bugWord)) {
-					try {
-						thisBug = new Bug(bug);
-						thisBugName = bugWord;
-						var = targetName;
-						return true;
-					} catch (JSONException e) {
-						e.printStackTrace();
-					}
-				}
-			}
-		}
-		return false;
+		return super.isToBeProcessedAccordingToSonar(element);
 	}
 
 	@Override

--- a/src/main/java/sonarquberepair/processor/sonarbased/DeadStoreProcessor.java
+++ b/src/main/java/sonarquberepair/processor/sonarbased/DeadStoreProcessor.java
@@ -1,13 +1,10 @@
 package sonarquberepair.processor.sonarbased;
 
 import spoon.reflect.code.CtAssignment;
-import spoon.reflect.code.CtCodeSnippetStatement;
 import spoon.reflect.code.CtLocalVariable;
 import spoon.reflect.code.CtStatement;
 
 public class DeadStoreProcessor extends SonarWebAPIBasedProcessor<CtStatement> {
-
-	String var; //contains name of variable which is uselessly assigned in the current bug.
 
 	public DeadStoreProcessor(String projectKey) {
 		super(1854, projectKey);
@@ -26,10 +23,6 @@ public class DeadStoreProcessor extends SonarWebAPIBasedProcessor<CtStatement> {
 
 	@Override
 	public void process(CtStatement element) {
-		System.out.println("BUG\n");
-		CtCodeSnippetStatement snippet = getFactory().Core().createCodeSnippetStatement();
-		final String value = String.format("//[Spoon inserted check], repairs sonarqube rule 1854:Dead stores should be removed,\n//useless assignment to %s removed", var);
-		snippet.setValue(value);
 		element.delete();
 	}
 

--- a/src/main/java/sonarquberepair/processor/sonarbased/SerializableFieldInSerializableClassProcessor.java
+++ b/src/main/java/sonarquberepair/processor/sonarbased/SerializableFieldInSerializableClassProcessor.java
@@ -1,6 +1,5 @@
 package sonarquberepair.processor.sonarbased;
 
-import org.json.JSONException;
 import spoon.reflect.code.CtComment;
 import spoon.reflect.declaration.CtField;
 import spoon.reflect.declaration.ModifierKind;
@@ -18,41 +17,7 @@ public class SerializableFieldInSerializableClassProcessor extends SonarWebAPIBa
 		if (element == null) {
 			return false;
 		}
-		long line = -1;
-		String targetName = "", fileOfElement = "";
-		line = (long) element.getPosition().getLine();
-		String split1[] = element.getPosition().getFile().toString().split("/");
-		fileOfElement = split1[split1.length - 1];
-		targetName = element.getSimpleName();
-		if (!setOfLineNumbers.contains(line) || !setOfFileNames.contains(fileOfElement)) {
-			return false;
-		}
-		try {
-			thisBug = new Bug();
-		} catch (Exception e) {
-			e.printStackTrace();
-		}
-
-		for (Bug bug : setOfBugs) {
-			if (bug.getLineNumber() != line || !bug.getFileName().equals(fileOfElement)) {
-				continue;
-			}
-
-			String bugName = bug.getName();
-			String[] split = bugName.split("\"");
-			for (String bugWord : split) {
-				if (targetName.equals(bugWord)) {
-					try {
-						thisBug = new Bug(bug);
-						thisBugName = bugWord;
-						return true;
-					} catch (JSONException e) {
-						e.printStackTrace();
-					}
-				}
-			}
-		}
-		return false;
+		return super.isToBeProcessedAccordingToSonar(element);
 	}
 
 	@Override

--- a/src/main/java/sonarquberepair/processor/sonarbased/SerializableFieldInSerializableClassProcessor.java
+++ b/src/main/java/sonarquberepair/processor/sonarbased/SerializableFieldInSerializableClassProcessor.java
@@ -1,10 +1,7 @@
 package sonarquberepair.processor.sonarbased;
 
-import spoon.reflect.code.CtComment;
 import spoon.reflect.declaration.CtField;
 import spoon.reflect.declaration.ModifierKind;
-
-import java.util.List;
 
 public class SerializableFieldInSerializableClassProcessor extends SonarWebAPIBasedProcessor<CtField> {
 
@@ -23,16 +20,6 @@ public class SerializableFieldInSerializableClassProcessor extends SonarWebAPIBa
 	@Override
 	public void process(CtField element) {
 		element.addModifier(ModifierKind.TRANSIENT);
-		List<CtComment> comments = element.getComments();
-		CtComment sp = null;
-		for (CtComment comment : comments) {
-			if (comment.getContent().indexOf("Noncompliant") != -1) {
-				sp = comment;
-			}
-		}
-		if (sp != null) {
-			element.removeComment(sp);
-		}
 	}
 
 }

--- a/src/main/java/sonarquberepair/processor/sonarbased/UnclosedResourcesProcessor.java
+++ b/src/main/java/sonarquberepair/processor/sonarbased/UnclosedResourcesProcessor.java
@@ -1,6 +1,5 @@
 package sonarquberepair.processor.sonarbased;
 
-import org.json.JSONException;
 import spoon.reflect.code.CtAssignment;
 import spoon.reflect.code.CtBlock;
 import spoon.reflect.code.CtCodeSnippetStatement;
@@ -27,44 +26,7 @@ public class UnclosedResourcesProcessor extends SonarWebAPIBasedProcessor<CtCons
 		if (element == null) {
 			return false;
 		}
-
-		long line = -1;
-		String targetName = "", fileOfElement = "";
-		targetName = element.getExecutable().getDeclaringType().getSimpleName();
-		line = (long) element.getPosition().getLine();
-		String split1[] = element.getPosition().getFile().toString().split("/");
-		fileOfElement = split1[split1.length - 1];
-
-		if (!setOfLineNumbers.contains(line) || !setOfFileNames.contains(fileOfElement)) {
-			return false;
-		}
-		try {
-			thisBug = new Bug();
-		} catch (Exception e) {
-			e.printStackTrace();
-		}
-
-		for (Bug bug : setOfBugs) {
-			if (bug.getLineNumber() != line || !bug.getFileName().equals(fileOfElement)) {
-				continue;
-			}
-
-			String bugName = bug.getName();
-			String[] split = bugName.split("\"");
-			for (String bugWord : split) {
-				if (targetName.equals(bugWord)) {
-					try {
-						thisBug = new Bug(bug);
-						thisBugName = bugWord;
-						var = targetName;
-						return true;
-					} catch (JSONException e) {
-						e.printStackTrace();
-					}
-				}
-			}
-		}
-		return false;
+		return super.isToBeProcessedAccordingToSonar(element);
 	}
 
 	@Override

--- a/src/test/java/sonarquberepair/processor/sonarbased/SerializableFieldInSerializableClassProcessorTest.java
+++ b/src/test/java/sonarquberepair/processor/sonarbased/SerializableFieldInSerializableClassProcessorTest.java
@@ -6,18 +6,19 @@ import org.sonar.java.checks.verifier.JavaCheckVerifier;
 import sonarquberepair.Constants;
 import sonarquberepair.Main;
 import sonarquberepair.PrettyPrintingStrategy;
+import sonarquberepair.TestHelper;
 
 public class SerializableFieldInSerializableClassProcessorTest {
 
 	@Test
 	public void test() throws Exception {
-
 		String fileName = "SerializableFieldProcessorTest.java";
 		String pathToBuggyFile = Constants.PATH_TO_FILE + fileName;
 		String pathToRepairedFile = "./spooned/" + fileName;
 
 		JavaCheckVerifier.verify(pathToBuggyFile, new SerializableFieldInSerializableClassCheck());
 		Main.repair(pathToBuggyFile, Constants.PROJECT_KEY, 1948, PrettyPrintingStrategy.NORMAL);
+		TestHelper.removeComplianceComments(pathToRepairedFile);
 		JavaCheckVerifier.verifyNoIssue(pathToRepairedFile, new SerializableFieldInSerializableClassCheck());
 	}
 

--- a/src/test/java/sonarquberepair/processor/sonarbased/UnclosedResourcesProcessorTest.java
+++ b/src/test/java/sonarquberepair/processor/sonarbased/UnclosedResourcesProcessorTest.java
@@ -12,7 +12,6 @@ public class UnclosedResourcesProcessorTest {
 
 	@Test
 	public void test() throws Exception {
-
 		String fileName = "ZipFolder.java";
 		String pathToBuggyFile = Constants.PATH_TO_FILE + fileName;
 		String pathToRepairedFile = "./spooned/" + fileName;
@@ -21,7 +20,6 @@ public class UnclosedResourcesProcessorTest {
 		Main.repair(pathToBuggyFile, Constants.PROJECT_KEY, 2095, PrettyPrintingStrategy.NORMAL);
 		TestHelper.removeComplianceComments(pathToRepairedFile);
 		JavaCheckVerifier.verifyNoIssue(pathToRepairedFile, new UnclosedResourcesCheck());
-
 	}
 
 }


### PR DESCRIPTION
This PR first aimed to simplify the Sonar-Web-API-based processors (and to remove duplicate code and unnecessary code). This was done. But then I found 3 bugs, which were also fixed in this PR.

#### First bug
`DeadStoreProcessor` was removing more things than it should:

Noncompliant code (test code):
```diff
        int x=5;
        int y=10;
        int z;
        y=x*x*y;
        System.out.println(y);
        x=5;// Noncompliant
        y=10;// Noncompliant
        z=20;// Noncompliant
```

The buggy fix (the repair generated by Sonarqube-repair):
```diff
        int x = 5;
        int y = 10;
-       int z;
        y = (x * x) * y;
        System.out.println(y);
-       x=5;// Noncompliant
-       y=10;// Noncompliant
-       z=20;// Noncompliant
```

The correct fix (the repair generated by Sonarqube-repair now with the changes in this PR):
```diff
        int x = 5;
        int y = 10;
        int z;
        y = (x * x) * y;
        System.out.println(y);
-       x=5;// Noncompliant
-       y=10;// Noncompliant
-       z=20;// Noncompliant
```

#### Second bug
`UnclosedResourcesProcessor` was removing the `catch` block in existing `try`s:

Noncompliant code (test code):
```diff
            ZipInputStream zipInput = null;
            try {
                zipInput = new ZipInputStream(new BufferedInputStream(new FileInputStream(file)));// Noncompliant
...
            } catch (Exception e) {
                Launcher.LOGGER.error(e.getMessage(), e);
            }
```

The buggy fix (the repair generated by Sonarqube-repair):
```diff
-          ZipInputStream zipInput = null;
-           try {
-               zipInput = new ZipInputStream(new BufferedInputStream(new FileInputStream(file)));// Noncompliant
+           try (ZipInputStream zipInput = new ZipInputStream(new BufferedInputStream(new FileInputStream(file)))) {
...
-           } catch (Exception e) {
-               Launcher.LOGGER.error(e.getMessage(), e);
            }
```

The correct fix (the repair generated by Sonarqube-repair now with the changes in this PR):
```diff
-          ZipInputStream zipInput = null;
-           try {
-               zipInput = new ZipInputStream(new BufferedInputStream(new FileInputStream(file)));// Noncompliant
+           try (ZipInputStream zipInput = new ZipInputStream(new BufferedInputStream(new FileInputStream(file)))) {
...
            } catch (Exception e) {
                Launcher.LOGGER.error(e.getMessage(), e);
            }

```

#### Third bug
`UnclosedResourcesProcessor` was placing a new `try-with-resources` in the wrong place:

Noncompliant code (test code):
```diff
            while ((entry = zipInput.getNextEntry()) != null) {
                File f = new File(destDir + File.separator + entry.getName());
                if (entry.isDirectory()) { // if its a directory, create it
                    f.mkdir();
                    continue;
                }
                // deflate in buffer
                final int buffer = 2048;
                // Force parent directory creation, sometimes directory was not yet handled
                f.getParentFile().mkdirs();
                // in the zip entry iteration
                OutputStream output = new BufferedOutputStream(new FileOutputStream(f));// Noncompliant
                int count;
                byte data[] = new byte[buffer];
                while ((count = zipInput.read(data, 0, buffer)) != -1) {
                    output.write(data, 0, count);
                }
                output.flush();
                output.close();
            }
```

The buggy fix (the repair generated by Sonarqube-repair):
```diff
            while ((entry = zipInput.getNextEntry()) != null) {
-                File f = new File(((destDir + (File.separator)) + (entry.getName())));
-                if (entry.isDirectory()) {
-                    // if its a directory, create it
-                    f.mkdir();
-                    continue;
-                }
-                // deflate in buffer
-                final int buffer = 2048;
-                // Force parent directory creation, sometimes directory was not yet handled
-                f.getParentFile().mkdirs();
-                // in the zip entry iteration
-                OutputStream output = new BufferedOutputStream(new FileOutputStream(f));// Noncompliant
-                int count;
-                byte[] data = new byte[buffer];
-                while ((count = zipInput.read(data, 0, buffer)) != (-1)) {
-                    output.write(data, 0, count);
-                } 
-                output.flush();
-                output.close();
+               try (// in the zip entry iteration
+               OutputStream output = new BufferedOutputStream(new FileOutputStream(f))
+                ) {
+                  File f = new File(((destDir + (File.separator)) + (entry.getName())));
+                   if (entry.isDirectory()) {
+                       // if its a directory, create it
+                       f.mkdir();
+                       continue;
+                   }
+                   // deflate in buffer
+                   final int buffer = 2048;
+                   // Force parent directory creation, sometimes directory was not yet handled
+                   f.getParentFile().mkdirs();
+                   int count;
+                   byte[] data = new byte[buffer];
+                   while ((count = zipInput.read(data, 0, buffer)) != (-1)) {
+                       output.write(data, 0, count);
+                   } 
+                   output.flush();
+                   output.close();
+                }
            }
```

The correct fix (the repair generated by Sonarqube-repair now with the changes in this PR):
```diff
            while ((entry = zipInput.getNextEntry()) != null) {
                File f = new File(destDir + File.separator + entry.getName());
                if (entry.isDirectory()) { // if its a directory, create it
                    f.mkdir();
                    continue;
                }
                // deflate in buffer
                final int buffer = 2048;
                // Force parent directory creation, sometimes directory was not yet handled
                f.getParentFile().mkdirs();
-               // in the zip entry iteration
-               OutputStream output = new BufferedOutputStream(new FileOutputStream(f));// Noncompliant
-               int count;
-               byte data[] = new byte[buffer];
-               while ((count = zipInput.read(data, 0, buffer)) != -1) {
-                   output.write(data, 0, count);
-               }
-               output.flush();
-               output.close();
+              try (// in the zip entry iteration
+              OutputStream output = new BufferedOutputStream(new FileOutputStream(f))
+              ) {
+                  int count;
+                  byte[] data = new byte[buffer];
+                  while ((count = zipInput.read(data, 0, buffer)) != (-1)) {
+                      output.write(data, 0, count);
+                  } 
+                  output.flush();
+                  output.close();
+                }
           }
```