### PR TITLE
Review test resources

### DIFF
--- a/docs/HANDLED_SONARQUBE_RULES.md
+++ b/docs/HANDLED_SONARQUBE_RULES.md
@@ -51,6 +51,17 @@ Example:
 +        BigDecimal bd3 = BigDecimal.valueOf(f); 
 ```
 
+When the constructor of `BigDecimal` being called has two arguments, being the first one of type `float` or `double`, that argument is changed to `String`.
+
+Example:
+```diff
+        MathContext mc;
+-       BigDecimal bd4 = new BigDecimal(2.0, mc); // Noncompliant {{Use "BigDecimal.valueOf" instead.}}
+-       BigDecimal bd6 = new BigDecimal(2.0f, mc); // Noncompliant {{Use "BigDecimal.valueOf" instead.}}
++       BigDecimal bd4 = new BigDecimal("2.0", mc);
++       BigDecimal bd6 = new BigDecimal("2.0", mc);
+```
+
 Check out an accepted PR in [Apache PDFBox](https://github.com/apache/pdfbox/pull/76) that repairs one BigDecimalDoubleConstructor violation.
 
 -----

--- a/src/test/java/sonarquberepair/processor/spoonbased/BigDecimalDoubleConstructorProcessorTest.java
+++ b/src/test/java/sonarquberepair/processor/spoonbased/BigDecimalDoubleConstructorProcessorTest.java
@@ -17,7 +17,7 @@ public class BigDecimalDoubleConstructorProcessorTest {
 		String pathToRepairedFile = "./spooned/" + fileName;
 
 		JavaCheckVerifier.verify(pathToBuggyFile, new BigDecimalDoubleConstructorCheck());
-		Main.repair(pathToBuggyFile, Constants.PROJECT_KEY, 2111, PrettyPrintingStrategy.SNIPER);
+		Main.repair(pathToBuggyFile, Constants.PROJECT_KEY, 2111, PrettyPrintingStrategy.NORMAL);
 		TestHelper.removeComplianceComments(pathToRepairedFile);
 		JavaCheckVerifier.verifyNoIssue(pathToRepairedFile, new BigDecimalDoubleConstructorCheck());
 	}

--- a/src/test/resources/ArrayHashCodeAndToString.java
+++ b/src/test/resources/ArrayHashCodeAndToString.java
@@ -1,17 +1,25 @@
-/**
- * Test for sonarqube rule s2116
- * Arrays should not have their .toString method called as this will return the reference which is almost always wrong.
- * Instead, Arrays.toString(ARRAY_VARIABLE) should be used.
- */
+// Test for rule s2116
 
 public class ArrayHashCodeAndToString {
 
+	// Tests from https://rules.sonarsource.com/java/type/Bug/RSPEC-2116
+	public static void main( String[] args ) {
+		String argStr = args.toString(); // Noncompliant
+		int argHash = args.hashCode(); // Noncompliant
+	}
+
+	// Tests from https://github.com/SonarSource/sonar-java/blob/master/java-checks-test-sources/src/main/java/checks/ArrayHashCodeAndToStringCheck.java
+	void method(String[] args, String string) {
+		Class class1 = args.getClass();
+		String str = string.toString();
+		int hash = string.hashCode();
+	}
+
+	// Aditional tests
 	public void foo(String[] args) {
 		String[] array1 = {"F", "O", "O"};
 		System.out.println(array1.toString()); // Noncompliant
 		varargsTest(1, 2, 3);
-		String argStr = args.toString(); // Noncompliant
-		int argHash = args.hashCode(); // Noncompliant
 	}
 
 	private void varargsTest(int... array2) {

--- a/src/test/resources/BigDecimalDoubleConstructor.java
+++ b/src/test/resources/BigDecimalDoubleConstructor.java
@@ -1,27 +1,33 @@
-/**
- * Test for sonarqube rule s2111.
- * From https://sonarqube.ow2.org/coding_rules#rule_key=squid%3AS2111:
- *
- * "The results of this constructor can be somewhat unpredictable. One might assume that writing new BigDecimal(0.1)
- * in Java creates a BigDecimal which is exactly equal to 0.1 (an unscaled value of 1, with a scale of 1),
- * but it is actually equal to 0.1000000000000000055511151231257827021181583404541015625.
- * This is because 0.1 cannot be represented exactly as a double (or, for that matter, as a binary fraction
- * of any finite length). Thus, the value that is being passed in to the constructor is not exactly equal to 0.1,
- * appearances notwithstanding".
- */
+// Test for rule s2111
+
 import java.math.BigDecimal;
+import java.math.MathContext;
 
 public class BigDecimalDoubleConstructor {
 
-    /*
-   Code taken from Sonarqube documentation https://sonarqube.ow2.org/coding_rules#rule_key=squid%3AS2111
-    */
+    // Tests from https://rules.sonarsource.com/java/type/Bug/RSPEC-2111
+    public void main(String[] args) {
+        double d = 1.1;
+        BigDecimal bd1 = new BigDecimal(d); // Noncompliant; see comment above
+        BigDecimal bd2 = new BigDecimal(1.1); // Noncompliant; same result
+    }
+
+    // Tests from https://github.com/SonarSource/sonar-java/blob/master/java-checks-test-sources/src/main/java/checks/BigDecimalDoubleConstructorCheck.java
+    public void main2(String[] args) {
+        MathContext mc;
+        BigDecimal bd1 = new BigDecimal("1");
+        BigDecimal bd2 = new BigDecimal(2.0); // Noncompliant {{Use "BigDecimal.valueOf" instead.}}
+        BigDecimal bd4 = new BigDecimal(2.0, mc); // Noncompliant {{Use "BigDecimal.valueOf" instead.}}
+        BigDecimal bd5 = new BigDecimal(2.0f); // Noncompliant {{Use "BigDecimal.valueOf" instead.}}
+        BigDecimal bd6 = new BigDecimal(2.0f, mc); // Noncompliant {{Use "BigDecimal.valueOf" instead.}}
+        BigDecimal bd3 = BigDecimal.valueOf(2.0);
+    }
+
+    // Aditional tests
     public void foo(String[] args) {
         double d = 1.1;
         float f = 2.2;
         float f1 = 2f;
-        BigDecimal bd1 = new BigDecimal(d); // Noncompliant
-        BigDecimal bd2 = new BigDecimal(1.1); // Noncompliant
         BigDecimal bd3 = new BigDecimal(f); // Noncompliant
         BigDecimal bd4 = new BigDecimal(f1); // Noncompliant
         BigDecimal bd5 = BigDecimal.valueOf(d); // Compliant

--- a/src/test/resources/CompareStringsBoxedTypesWithEquals.java
+++ b/src/test/resources/CompareStringsBoxedTypesWithEquals.java
@@ -1,11 +1,16 @@
-/**
- * Test for sonarqube rule s4973
- * Boxed types should be compared with equals() rather than "==" since equals compares values while
- * "==" compares memory location.
- */
+// Test for rule s4973
 
 public class CompareStringsBoxedTypesWithEquals {
 
+    // Test from https://rules.sonarsource.com/java/type/Bug/RSPEC-4973
+    public void main(String[] args) {
+        String firstName = getFirstName(); // String overrides equals
+        String lastName = getLastName();
+
+        if (firstName == lastName) { } ; // Noncompliant; false even if the strings have the same value
+    }
+
+    // Aditional tests
     boolean eq = true;
 
     // Java implicitly converts one variable to primitive if something boxed and primitive is compared.
@@ -39,7 +44,7 @@ public class CompareStringsBoxedTypesWithEquals {
     }
 
     // ENUM comparisons are excluded from transformation
-    private void nullCompare() {
+    private void nullCompare2() {
         enum foo {
             BAR,
             XOR

--- a/src/test/resources/IteratorNextException.java
+++ b/src/test/resources/IteratorNextException.java
@@ -1,10 +1,9 @@
-/**
- * Test for sonarqube rule s2272
- * By contract, any implementation of Iterator.next() should throw a NoSuchElementException when there are no more elements.
- */
+// Test for rule s2272
+
 import java.util.Iterator;
 import java.util.Stack;
 
+// Test based on https://rules.sonarsource.com/java/type/Bug/RSPEC-2272
 public class IteratorNextException implements Iterator {
 
     private Stack<String> stack = new Stack();


### PR DESCRIPTION
It's important that our processors work well at least on the cases presented by Sonar, the ones that are basic, which can be found in https://rules.sonarsource.com/java and https://github.com/SonarSource/sonar-java/tree/master/java-checks-test-sources. This PR reviews our test resources according to those sources.

After it, I found a bug in `BigDecimalDoubleConstructorProcessor`, which was exposed by new test examples added from Sonar by this PR. The thing is: `BigDecimalDoubleConstructorProcessor` works only on the constructor `BigDecimal(double)`, which failed in the following new test cases:

```java
MathContext mc;
BigDecimal bd4 = new BigDecimal(2.0, mc); // Noncompliant {{Use "BigDecimal.valueOf" instead.}}
BigDecimal bd6 = new BigDecimal(2.0f, mc); // Noncompliant {{Use "BigDecimal.valueOf" instead.}}
```

This PR already adds the fix for that. See, now `BigDecimalDoubleConstructorProcessor` produces two types of patches.

Already existing one:
```diff
-       BigDecimal bd2 = new BigDecimal(1.1); // Noncompliant
+       BigDecimal bd2 = BigDecimal.valueOf(1.1); 
```

New one:
```diff
        MathContext mc;
-       BigDecimal bd4 = new BigDecimal(2.0, mc); // Noncompliant {{Use "BigDecimal.valueOf" instead.}}
+       BigDecimal bd4 = new BigDecimal("2.0", mc);
```