### PR TITLE
change groupId to se.kth.castor

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
 
-    <groupId>se.kth</groupId>
+    <groupId>se.kth.castor</groupId>
     <artifactId>sonarqube-repair</artifactId>
     <version>1.1-SNAPSHOT</version>
 


### PR DESCRIPTION
Soon, we'll deploy a snapshot on Maven Central, if not a release.

We cannot deploy with groupId se.kth

We we can deploy to se.kth.castor, hence this PR.